### PR TITLE
Corrected option handling, and handled deep directory paths.

### DIFF
--- a/scripts/shcov
+++ b/scripts/shcov
@@ -174,8 +174,6 @@ if __name__ == "__main__":
             break
     args = sys.argv[last:]
 
-    print outpath
-    print shell
     if len(args) < 1:
         usage()
 


### PR DESCRIPTION
These commits fix the errors in handling the --output and --shell options, and adds a check to ensure that the line parsed into four parts (which it won't if the directory depth is >100 bytes, or, I suppose, if someone had a directory in the path named ':::', but this doesn't address that.)

I tested these on a RHEL6 machine, but I could not run shcov on my Mac from whence I committed them. 
