### PR TITLE
Add an info summary on standard output.

### DIFF
--- a/scripts/shcov
+++ b/scripts/shcov
@@ -15,6 +15,8 @@
 
 import os, sys, subprocess, pickle, signal, select
 
+DEFAULT_OUTPATH = os.path.join(os.environ.get("TMPDIR", "/tmp"), "shcov")
+
 base_dir = os.path.abspath(sys.path[0] + "/../")
 sys.path =  [base_dir] + sys.path
 
@@ -23,7 +25,7 @@ import shcov
 from shcov.file import File
 
 class ShcovCollector:
-    def __init__(self, args, outpath = "/tmp/shcov", shell = ["bash", "-x"]):
+    def __init__(self, args, outpath = DEFAULT_OUTPATH, shell = ["bash", "-x"]):
         self.files = {}
         self.args = args
         self.outpath = outpath
@@ -134,11 +136,17 @@ class ShcovCollector:
             os.unlink( self.outpath + file.path + ".%d.pkl" % (self.pid) )
 
 def usage():
-    print "Usage: shcov [-h] [--output=where] [--shell=what] script...\n"
-    print "Produce coverage data for 'script'. Options are\n"
-    print "  --output=where  write data to 'where' instead of /tmp/shcov"
-    print "  --shell=what    ues 'what' (including arguments) as shell instead of 'bash -x'"
-
+    print """Usage: shcov [options] script [script_args...]
+Summary:
+    Produce coverage data for 'script'. Options are\n"
+Options:
+    -o --output=where   Path to write data (default: ${TMPDIR:-/tmp}/shcov)
+    -s --shell=what     Shell to use, including arguments (default: 'bash -x')
+Environment:
+    SHCOV_DATADIR       Same as '--output' but can be set in the user's
+                        environment and exported to all sub processes.  Note
+                        that the '--output' option overrides SHCOV_DATADIR.
+"""
     sys.exit(1)
 
 glob_sc = None
@@ -154,7 +162,7 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         usage()
 
-    outpath = "/tmp/shcov"
+    outpath = os.environ.get("SHCOV_DATADIR", DEFAULT_OUTPATH)
     shell = ["bash", "-x"]
 
     # Really, really, ugly, but it's done this way to avoid parsing the

--- a/scripts/shlcov
+++ b/scripts/shlcov
@@ -29,13 +29,14 @@ case_nr_regexp = re.compile("\A(([\',\",0-9,a-z,A-Z,_, ]+)|\*{1})\){1}\\Z")
 heredoc_regexp = re.compile(".*<<-?\'?([a-zA-Z]+)\'?")
 
 class ShcovDataOutput:
-    def __init__(self, script_base, inpath, outpath, low_limit = 15, high_limit = 50):
+    def __init__(self, script_base, inpath, outpath, low_limit = 15, high_limit = 50, info_sum = False):
         self.script_base = script_base
         self.inpath = inpath
         self.outpath = outpath
 
         self.low_limit = low_limit
         self.high_limit = high_limit
+        self.info_sum = info_sum
 
         self.files = []
 
@@ -365,6 +366,9 @@ class ShcovDataOutput:
         of = open(os.path.join(self.outpath, "index.html"), "w")
         self.write_header(of, "/", "", total_lines, executed_lines)
 
+        if self.info_sum:
+            print "(%.2f%%) covered" % ((float(executed_lines) / float(total_lines)) * 100.0)
+
         self.write_directory_header(of)
 
         for dir in dirs.values():
@@ -443,27 +447,37 @@ class ShcovDataOutput:
                 shutil.copyfile(path, os.path.join(self.outpath, name))
 
 def usage():
-    print "Usage: shlcov [--script-base=path] [--limit=low,high] datadir outdir\n"
-    print "Create HTML output of shcov data in 'datadir' in 'outdir'.\n"
-    print "Options are"
-    print "  --script-base=path   set the base path to lookup script source (default '')"
-    print "  --limit=low,high     set the low and high coverage limits (default 15,50)"
-
+    print """Usage: shlcov [options] datadir outdir
+Summary:
+    Create HTML output of shcov data in 'datadir' in 'outdir'.
+Options:
+    -s --script-base=path     Base path to lookup script source (default: '')
+    -l --limit=low,high       Coverage limits (default: 15,50)
+    -i --info-summary         Generate info summary on standard output.
+"""
     sys.exit(1)
 
 if __name__ == "__main__":
     script_base = ''
     low_limit = 15
     high_limit = 50
+    info_sum = False
 
     try:
-        optlist, args = getopt.gnu_getopt(sys.argv[1:], "hs:l:", ["help", "script-base=", "limit="])
+        optlist, args = getopt.gnu_getopt(sys.argv[1:], "hs:l:i", [
+            "help",
+            "script-base=",
+            "limit=",
+            "info-summary"
+        ])
     except:
         usage()
 
     for opt, arg in optlist:
         if opt in ("-h", "--help"):
             usage()
+        if opt in ("-i", "--info-summary"):
+            info_sum = True
         if opt in ("-s", "--script-base"):
             script_base = arg
         if opt in ("-l", "--limit"):
@@ -479,5 +493,5 @@ if __name__ == "__main__":
     if len(args) < 2:
         usage()
 
-    sc = ShcovDataOutput(script_base, args[0], args[1], low_limit, high_limit)
+    sc = ShcovDataOutput(script_base, args[0], args[1], low_limit, high_limit, info_sum)
     sc.run()

--- a/shcov.1
+++ b/shcov.1
@@ -1,4 +1,4 @@
-.TH SHCOV 1 "December 14, 2008"
+.TH SHCOV 1 "February 26, 2015"
 .SH NAME
 shcov - collect execution coverage information for shell scripts
 .SH DESCRIPTION
@@ -11,12 +11,21 @@ tool to create HTML output of coverage information.
 \fBshcov [--output=where] [--shell=shell] script ...\fR
 .TP
 \fB\--output=\fR \fIwhere\fR
-Place output in \fIwhere\fR instead of \fI/tmp/shcov\fR
+Place output in \fIwhere\fR instead of the default.  By default, \fIshcov\fR
+will read the POSIX \fITMPDIR\fR environment variable for the path of the
+temporary directory, before defaulting to \fI/tmp\fR.  This path is then used
+as a prefix to the data directory, i.e. \fI/tmp/shcov\fR.
 .PP
 .TP
 \fB\--shell=\fR \fIwhat\fR
 Use shell command line \fIwhat\fR instead of \fIbash -x\fR
 .PP
+.SH ENVIRONMENT
+\fBSHCOV_DATADIR\fR
+This can be used instead of or in conjunction with the \fI\--output\fR option.
+If the \fI\--output\fR option is set, this will override the \fISHCOV_DATADIR\fR
+setting.  This is useful for setting the path globally, such as within a build
+chroot or on a build machine.
 .SH HOMEPAGE
 http://shcov.googlecode.com
 .SH SEE ALSO


### PR DESCRIPTION
This is to allow build runners like those on GitLab and GitHub to parse
the build log for the coverage score and display it on the build results
page.
